### PR TITLE
Update version of tardigrade-ci to 0.24.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM plus3it/tardigrade-ci:0.24.6
+FROM plus3it/tardigrade-ci:0.24.11


### PR DESCRIPTION
Bump the version manually so we can use the new test json for localstack.